### PR TITLE
Fix get.sh script with grep -i

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 inlets
 inlets-linux
 inlets-darwin
+.idea/

--- a/get.sh
+++ b/get.sh
@@ -6,7 +6,7 @@ export REPO=inlets
 export SUCCESS_CMD="$REPO version"
 export BINLOCATION="/usr/local/bin"
 
-version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep Location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
+version=$(curl -sI https://github.com/$OWNER/$REPO/releases/latest | grep -i location | awk -F"/" '{ printf "%s", $NF }' | tr -d '\r')
 
 if [ ! $version ]; then
     echo "Failed while attempting to install $REPO. Please manually install:"


### PR DESCRIPTION
## Description
Github made the location header lowercase, so our get.sh script was failing. This makes the grep case inseneitive.


Tested by running the script to make sure it failed, then making the
grep into a grep -i and running again, this time it worked.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests